### PR TITLE
Update slang checker to use regex

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -8,7 +8,7 @@ const formatDate = (date) => {
 const moderateMessagesCommand = (message) => {
     let slangsUsed = [];
     moderate.forEach((msg) => {
-        if (message.content.includes(msg)) {
+        if (new RegExp("\\b" + msg + "\\b").test(message.content)) {
             slangsUsed.push(msg);
         }
     });


### PR DESCRIPTION
[`includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) is not the best way to check if a user's message contains slang language; you would've seen this behaviour when there was a warning for a slang word being used in a message which contained the word "passport".

^here you can see that `includes` will match just about any substring in the given string.

A better and more reliable way to go about this could be test if the *complete* slang word is there in the message, and that's what this PR aims to do, using regex!